### PR TITLE
fix gaps in empty node ord and delete BOM

### DIFF
--- a/cu_proiel-ud-dev.conllu
+++ b/cu_proiel-ud-dev.conllu
@@ -23908,7 +23908,7 @@
 5	имете	ѩти	VERB	V-	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin|Voice=Act	0	root	0:root	ref=LUKE_22.67|proiel-id=602893
 5.1	_	_	PRON	_	_	_	_	5:nsubj	ref=|proiel-id=2704771|information-status=old|antecedent-proiel-id=602890
 6	вѣрꙑ	вѣра	NOUN	Nb	Case=Gen|Gender=Fem|Number=Sing	5	obj	5:obj	ref=LUKE_22.67|proiel-id=602894
-6.2	_	_	PRON	_	_	_	_	5:obl	ref=|proiel-id=2704772|information-status=acc_inf|antecedent-proiel-id=602891
+6.1	_	_	PRON	_	_	_	_	5:obl	ref=|proiel-id=2704772|information-status=acc_inf|antecedent-proiel-id=602891
 
 # source = Codex Marianus, Luke 22
 # text = аште же и въпрошѫ вꙑ не отъвѣштаате ми ни поустите

--- a/cu_proiel-ud-test.conllu
+++ b/cu_proiel-ud-test.conllu
@@ -20412,7 +20412,7 @@
 4	въдати	въдати	VERB	V-	Tense=Pres|VerbForm=Inf|Voice=Act	3	xcomp	3:xcomp	ref=MATT_27.58|proiel-id=581509
 4.1	_	_	PRON	_	_	_	_	4:nsubj	ref=|proiel-id=2701608|information-status=non_spec
 5	тѣло	тѣло	NOUN	Nb	Case=Acc|Gender=Neut|Number=Sing	4	obj	4:obj	ref=MATT_27.58|proiel-id=581510|information-status=old|antecedent-proiel-id=581503
-5.2	_	_	PRON	_	_	_	_	4:obl	ref=|proiel-id=2701704|information-status=old|antecedent-proiel-id=581498
+5.1	_	_	PRON	_	_	_	_	4:obl	ref=|proiel-id=2701704|information-status=old|antecedent-proiel-id=581498
 6	и҃сво	исоусовъ	ADJ	A-	Case=Acc|Degree=Pos|Gender=Neut|Number=Sing|Variant=Short	5	amod	5:amod	ref=MATT_27.58|proiel-id=581511
 
 # source = Codex Marianus, Matthew 27


### PR DESCRIPTION
GitHub diff does not show the BOM sequence, but e.g. in Psalterium Sinaiticum, Psalms 17
`ref=﻿\ufeff17.1` is changed into `ref=﻿17.1`.